### PR TITLE
--ESM

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-import { createHook } from 'node:async_hooks'
-import { readFileSync } from 'node:fs'
-import { relative } from 'node:path'
-import { fileURLToPath } from 'node:url'
+const {createHook} = require('node:async_hooks')
+const {readFileSync} = require('node:fs')
+const {relative} = require('node:path')
+const {fileURLToPath} = require('node:url')
 
 const IGNORED_TYPES = [
   'TIMERWRAP',
@@ -32,7 +32,7 @@ const hook = createHook({
 
 hook.enable()
 
-export default function whyIsNodeRunning (logger = console) {
+function whyIsNodeRunning (logger = console) {
   hook.disable()
 
   const activeAsyncResources = Array.from(asyncResources.values())
@@ -44,6 +44,7 @@ export default function whyIsNodeRunning (logger = console) {
     printStacks(asyncResource, logger)
   }
 }
+module.exports = whyIsNodeRunning
 
 function printStacks (asyncResource, logger) {
   const stacks = asyncResource.stacks.filter((stack) => !stack.getFileName().startsWith('node:'))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "why-is-node-running",
-  "type": "module",
   "version": "3.2.0",
   "description": "Node is running but you don't know why? why-is-node-running is here to help you.",
   "exports": {


### PR DESCRIPTION
fix esm import resistence isssue for ts-node


> startup-manager@0.1.0 server
> ts-node --project tsconfig.server.json src/server.ts

/root/programs/startup-manager/node_modules/ts-node/dist/index.js:851
            return old(m, filename);
                   ^
Error [ERR_REQUIRE_ESM]: require() of ES Module /root/programs/startup-manager/node_modules/why-is-node-running/index.js from /root/programs/startup-manager/src/server.ts not supported.
Instead change the require of index.js in /root/programs/startup-manager/src/server.ts to a dynamic import() which is available in all CommonJS modules.
    at require.extensions.<computed> [as .js] (/root/programs/startup-manager/node_modules/ts-node/dist/index.js:851:20)
    at mod.require (/root/programs/startup-manager/node_modules/next/dist/server/require-hook.js:65:28)
    at Object.<anonymous> (/root/programs/startup-manager/src/server.ts:12:47)
    at m._compile (/root/programs/startup-manager/node_modules/ts-node/dist/index.js:857:29) {
  code: 'ERR_REQUIRE_ESM'
}
root@vmi969203:~/programs/startup-manager# 

tsconfig.json
{
  "compilerOptions": {
    "target": "ES2019",
    "lib": ["dom", "dom.iterable", "esnext"],
    "allowJs": true,
    "skipLibCheck": true,
    "strict": true,
       "noEmit": false,
    "esModuleInterop": true,
    "module": "CommonJS",
    "moduleResolution": "Node",
    "resolveJsonModule": true,
    "outDir": "dist",
    "isolatedModules": false,
    "jsx": "preserve",
    "incremental": true,
    "plugins": [
      {
        "name": "next"
      }
    ],
    "paths": {
      "@/*": ["./src/*"]
    }
  },
  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts","src/server.ts", "src/lib/**/*.ts"],
  "exclude": ["node_modules"]
}
